### PR TITLE
Make _croppie public

### DIFF
--- a/projects/ngx-super-croppie/src/lib/ngx-super-croppie.component.ts
+++ b/projects/ngx-super-croppie/src/lib/ngx-super-croppie.component.ts
@@ -94,7 +94,7 @@ export class NgxSuperCroppieComponent implements OnInit {
   /**
    * croppie object
    */
-  private _croppie: Croppie;
+  _croppie: Croppie;
 
   /**
    * init cropper


### PR DESCRIPTION
Make _croppie public so we can have direct access to original croppie functionality.